### PR TITLE
Bugfix: fix gradle issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Trigger Jenkins build
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
         run: |
-          curl -X POST "http://51.81.32.234:8080/job/FCFB-Discord-Ref-Bot_PRD/build?token=${{ secrets.JENKINS_TOKEN }}" \
+          curl -X POST "http://51.81.32.234:8080/job/FCFB-Bot-Health/build?token=${{ secrets.JENKINS_TOKEN }}" \
             -u "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
             -H "Jenkins-Crumb: ${{ steps.get_crumb.outputs.crumb }}"
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,7 +78,7 @@ tasks.withType<Copy> {
 }
 
 tasks.jar {
-    manifest.attributes["Main-Class"] = "com.fcfb.discord.refbot.FCFBDiscordRefBotKt"
+    manifest.attributes["Main-Class"] = "com.fcfb.discord.refbot.FCFBBotHealthKt"
     val dependencies =
         configurations
             .runtimeClasspath


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change modifies the Jenkins job URL that is triggered on a push to the main branch.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L123-R123): Updated the Jenkins job URL from `FCFB-Discord-Ref-Bot_PRD` to `FCFB-Bot-Health`.